### PR TITLE
FIX Remove PHP 5.5, increase to 5.6 minimum, rename repository paths in readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/change-log.md
+++ b/change-log.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 2.0.0 (unreleased)
 
 * SilverStripe 4 minimum required
-* PHP 5.5 minimum required
+* PHP 5.6 minimum required
 
 ## 1.0.0
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "SilverStripe integration with Crazy Egg",
     "type": "silverstripe-module",
     "require": {
-        "php": ">=5.5",
+        "php": ">=5.6",
         "silverstripe/framework": "^4.0@dev"
     },
     "require-dev": {

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ This module integrates Crazy Egg tracking with SilverStripe.
 ## Requirements
 
 - SilverStripe ^4.0
-- PHP 5.5 or above
+- PHP 5.6 or above
 
 ## Installation
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # SilverStripe Crazy Egg
 
-[![Build Status](http://img.shields.io/travis/robbieaverill/silverstripe-crazy-egg.svg?style=flat-square)](https://travis-ci.org/robbieaverill/silverstripe-crazy-egg)
-[![Code Quality](http://img.shields.io/scrutinizer/g/robbieaverill/silverstripe-crazy-egg.svg?style=flat-square)](https://scrutinizer-ci.com/g/robbieaverill/silverstripe-crazy-egg)
+[![Build Status](http://img.shields.io/travis/silverstripe/silverstripe-crazy-egg.svg?style=flat-square)](https://travis-ci.org/silverstripe/silverstripe-crazy-egg)
+[![Code Quality](http://img.shields.io/scrutinizer/g/silverstripe/silverstripe-crazy-egg.svg?style=flat-square)](https://scrutinizer-ci.com/g/silverstripe/silverstripe-crazy-egg)
 [![Version](http://img.shields.io/packagist/v/silverstripe/crazy-egg.svg?style=flat-square)](https://packagist.org/packages/silverstripe/silverstripe-crazy-egg)
 [![License](http://img.shields.io/packagist/l/silverstripe/crazy-egg.svg?style=flat-square)](LICENSE.md)
 
@@ -40,4 +40,4 @@ All methods, with `public` visibility, are part of the public API. All other met
 
 ## Reporting Issues
 
-Please [create an issue](http://github.com/robbieaverill/silverstripe-crazy-egg/issues) for any bugs you've found, or features you're missing.
+Please [create an issue](http://github.com/silverstripe/silverstripe-crazy-egg/issues) for any bugs you've found, or features you're missing.


### PR DESCRIPTION
- [x] May require a shift in Travis/Scrutinizer to the silverstripe organisation

Resolves #5 